### PR TITLE
fix: missing latest push

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -90,25 +90,28 @@ jobs:
 
       - name: Push images
         run: |
-          # push frontend and backend images with a unique sha and latest
+          # tag images with sha
           
           docker image tag url-shortener-backend:latest \
             anrayliu/url-shortener-backend:${{ github.sha }}
           docker image tag url-shortener-backend:latest \
-            anrayliu/url-shortener-backend:latest
-
-          docker image tag url-shortener-frontend:latest \
-            anrayliu/url-shortener-frontend:${{ github.sha }}
-          docker image tag url-shortener-frontend:latest \
-            anrayliu/url-shortener-frontend:latest
-
-          docker push anrayliu/url-shortener-frontend:${{ github.sha }}
-          docker push anrayliu/url-shortener-backend:${{ github.sha }}
-          docker push anrayliu/url-shortener-frontend:latest
-          docker push anrayliu/url-shortener-backend:latest
+            anrayliu/url-shortener-backend:${{ github.sha }}
           docker image tag url-shortener-database:latest \
             anrayliu/url-shortener-database:${{ github.sha }}
+
+          # tag images with latest
+
+          docker image tag url-shortener-frontend:latest \
+            anrayliu/url-shortener-frontend:latest
+          docker image tag url-shortener-frontend:latest \
+            anrayliu/url-shortener-frontend:latest
+          docker image tag url-shortener-database:latest \
+            anrayliu/url-shortener-database:latest
 
           docker push anrayliu/url-shortener-frontend:${{ github.sha }}
           docker push anrayliu/url-shortener-backend:${{ github.sha }}
           docker push anrayliu/url-shortener-database:${{ github.sha }}
+
+          docker push anrayliu/url-shortener-frontend:latest
+          docker push anrayliu/url-shortener-backend:latest
+          docker push anrayliu/url-shortener-database:latest


### PR DESCRIPTION
fixes a bug where cicd cannot scan latest images because the latest tags are not pushed.