### PR TITLE
feat: add jenkins file

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -68,7 +68,9 @@ pipeline {
         }
 
         stage('Deploy') {
-            echo "deployments will happen here"
+            steps {
+                echo "deployments will happen here"
+            }
         }
 
     }


### PR DESCRIPTION
To make this project, I'm faced with a difficult architectural problem.

I want to have a prod environment with blue/green deployment, a dev environment with standard rolling deployments, and the app is 3 tiered. For prod, that's 1 blue vm, 1 green vm, 1 load balancer, 1 database, and 1 web server. For dev, that's still 3 vms for the 3 tiers, totaling 8 vms. If I host this project on the cloud, that will be quite expensive. 

On the other hand, I have a local proxmox server I can leverage. The issue is, most of my cicd has already been written for this public github repo, and I didn't want to change that. For the cicd to make deployments to my local hardware, I would have to open up my server to public internet, which of course, I didn't want to do.

The solution? Bridge my github actions cicd with a local Jenkins pipeline. My jenkins will run locally, blocking all inbound traffic. It will instead poll my public repo, and once it sees my cicd going off, will trigger its own pipeline. Now I get full access to my local vms, while still be "triggered" by github workflows.

Mind the messy commits, there was a lot of trial and error to get the bridge to work