### PR TITLE
test: remove workspace cleanup

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -118,10 +118,4 @@ pipeline {
             }
         }
     }
-
-    post {
-        always {
-            cleanWs()
-        }
-    }
 }


### PR DESCRIPTION
jenkins is constantly running polled jobs even with no change. I'm suspecting this may have something to do with it