### PR TITLE
chore: disable dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,4 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0

--- a/README.md
+++ b/README.md
@@ -15,4 +15,4 @@ Goal: Develop and deploy an app from scratch using a modern tech stack while tou
 - On-prem system. Everything is ran on my bare-metal server.
 - Local testing simplified with Docker Compose.
 - Bread and butter observability with Prometheus and Grafana.
-- Stay on guard with daily Trivy and Dependabot vulernability scans.
+- Daily Trivy and Dependabot vulernability scans.


### PR DESCRIPTION
keeping only security updates